### PR TITLE
Inherit cert org and country from CA

### DIFF
--- a/lib/ritm/certs/certificate.rb
+++ b/lib/ritm/certs/certificate.rb
@@ -13,11 +13,12 @@ module Ritm
       new cert
     end
 
-    def self.create(common_name, serial_number: nil)
+    def self.create(common_name, ca: nil, serial_number: nil)
       cert = CertificateAuthority::Certificate.new
       cert.subject.common_name = common_name
-      cert.subject.organization = cert.subject.organizational_unit = 'RubyInTheMiddle'
-      cert.subject.country = 'AR'
+      cert.subject.organization = ca.cert.distinguished_name.organization || 'RubyInTheMiddle'
+      cert.subject.organizational_unit = ca.cert.distinguished_name.organization || 'RubyInTheMiddle'
+      cert.subject.country = ca.cert.distinguished_name.country || 'AR'
       cert.not_before = cert.not_before - 3600 * 24 * 30 # Substract 30 days
       cert.serial_number.number = serial_number || common_name.hash.abs
       cert.key_material.generate_key(1024)

--- a/lib/ritm/proxy/cert_signing_https_server.rb
+++ b/lib/ritm/proxy/cert_signing_https_server.rb
@@ -33,7 +33,7 @@ module Ritm
         ctx.servername_cb = proc do |sock, servername|
           mutex.synchronize do
             unless contexts.include? servername
-              cert = Ritm::Certificate.create(servername)
+              cert = Ritm::Certificate.create(servername, ca: ca)
               ca.sign(cert)
               contexts[servername] = context_with_cert(sock.context, cert)
             end

--- a/lib/ritm/proxy/ssl_reverse_proxy.rb
+++ b/lib/ritm/proxy/ssl_reverse_proxy.rb
@@ -38,7 +38,7 @@ module Ritm
       private
 
       def gen_signed_cert(common_name)
-        cert = Ritm::Certificate.create(common_name)
+        cert = Ritm::Certificate.create(common_name, ca: @ca)
         @ca.sign(cert)
         cert
       end


### PR DESCRIPTION
This PR passes the CA details to `Certificate.create`, allowing the certificate to be generated with the same `Organization`, `Organization Unit`, and `Country` properties; rather than `RubyInTheMiddle`, `RubyInTheMiddle`, and `AR` respectively.

Rather than passing the entire `ca` object, it may be a better idea to pass only the appropriate properties of the `distinguished_name` property of the `ca` object - although this would double the number of optional arguments to the `Certificate.create` method.

Alternatively, it would be nice if the user could specify these options in the `ssl_reverse_proxy` portion of the `RITM.configure` block.