### PR TITLE
Fixes #18: Cookies bugfix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.2
 
+Documentation:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Max: 9
 

--- a/lib/ritm/configuration.rb
+++ b/lib/ritm/configuration.rb
@@ -2,7 +2,6 @@ require 'dot_hash'
 require 'set'
 
 module Ritm
-  # Global Ritm settings
   class Configuration
     def default_settings # rubocop:disable Metrics/MethodLength
       {
@@ -60,12 +59,10 @@ module Ritm
       end
     end
 
-    # Re-enable interception
     def enable
       @settings.intercept[:enabled] = true
     end
 
-    # Disable interception
     def disable
       @settings.intercept[:enabled] = false
     end

--- a/lib/ritm/helpers/encodings.rb
+++ b/lib/ritm/helpers/encodings.rb
@@ -1,7 +1,6 @@
 require 'zlib'
 
 module Ritm
-  # ENCODER/DECODER of HTTP content
   module Encodings
     ENCODINGS = %i[identity gzip deflate].freeze
 
@@ -34,7 +33,6 @@ module Ritm
     class << self
       private
 
-      # Returns data unchanged. Identity is the default value of Accept-Encoding headers.
       def identity(data)
         data
       end

--- a/lib/ritm/interception/http_forwarder.rb
+++ b/lib/ritm/interception/http_forwarder.rb
@@ -67,7 +67,8 @@ module Ritm
       webrick_response.status = faraday_response.status
       webrick_response.body = faraday_response.body
       faraday_response.headers.each do |name, value|
-        if name == 'set-cookie'
+        case name
+        when 'set-cookie'
           WEBrick::Cookie.parse_set_cookies(value).each { |cookie| webrick_response.cookies << cookie }
         else
           webrick_response[name] = value

--- a/lib/ritm/interception/request_interceptor_servlet.rb
+++ b/lib/ritm/interception/request_interceptor_servlet.rb
@@ -1,12 +1,11 @@
 require 'webrick'
-require 'ritm/interception/http_forwarder'
 
 module Ritm
   # Actual implementation of the SSL Reverse Proxy service (decoupled from the certificate handling)
   class RequestInterceptorServlet < WEBrick::HTTPServlet::AbstractServlet
-    def initialize(server, request_interceptor, response_interceptor, conf)
+    def initialize(server, forwarder)
       super server
-      @forwarder = HTTPForwarder.new(request_interceptor, response_interceptor, conf)
+      @forwarder = forwarder
     end
 
     def service(request, response)

--- a/lib/ritm/main.rb
+++ b/lib/ritm/main.rb
@@ -1,6 +1,5 @@
 require 'ritm/session'
 
-# Main module
 module Ritm
   GLOBAL_SESSION = Session.new
 

--- a/lib/ritm/proxy/cert_signing_https_server.rb
+++ b/lib/ritm/proxy/cert_signing_https_server.rb
@@ -9,7 +9,7 @@ module Ritm
   module Proxy
     # Patches WEBrick::HTTPServer SSL context creation to get
     # a callback on the 'Client Helo' step of the SSL-Handshake if SNI is specified
-    # So we can create self-signed certificates on the fly
+    # So RitM can create self-signed certificates on the fly
     class CertSigningHTTPSServer < WEBrick::HTTPServer
       # Override
       def setup_ssl_context(config)

--- a/lib/ritm/proxy/launcher.rb
+++ b/lib/ritm/proxy/launcher.rb
@@ -14,13 +14,11 @@ module Ritm
         build_proxy
       end
 
-      # Starts the service (non blocking)
       def start
         @https.start_async
         @http.start_async
       end
 
-      # Stops the service
       def shutdown
         @https.shutdown
         @http.shutdown

--- a/lib/ritm/proxy/launcher.rb
+++ b/lib/ritm/proxy/launcher.rb
@@ -2,6 +2,7 @@ require 'ritm/proxy/ssl_reverse_proxy'
 require 'ritm/proxy/proxy_server'
 require 'ritm/certs/ca'
 require 'ritm/interception/handlers'
+require 'ritm/interception/http_forwarder'
 
 module Ritm
   module Proxy
@@ -32,8 +33,10 @@ module Ritm
         ssl_proxy_host = @conf.ssl_reverse_proxy.bind_address
         ssl_proxy_port = @conf.ssl_reverse_proxy.bind_port
         @https_forward = "#{ssl_proxy_host}:#{ssl_proxy_port}"
-        @request_interceptor = default_request_handler(session)
-        @response_interceptor = default_response_handler(session)
+
+        request_interceptor = default_request_handler(session)
+        response_interceptor = default_response_handler(session)
+        @forwarder = HTTPForwarder.new(request_interceptor, response_interceptor, @conf)
 
         crt_path = @conf.ssl_reverse_proxy.ca.pem
         key_path = @conf.ssl_reverse_proxy.ca.key
@@ -47,17 +50,14 @@ module Ritm
                                              Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
                                              https_forward: @https_forward,
                                              ProxyVia: nil,
-                                             request_interceptor: @request_interceptor,
-                                             response_interceptor: @response_interceptor,
+                                             forwarder: @forwarder,
                                              ritm_conf: @conf)
       end
 
       def build_reverse_proxy
         @https = Ritm::Proxy::SSLReverseProxy.new(@conf.ssl_reverse_proxy.bind_port,
                                                   @certificate,
-                                                  @conf,
-                                                  request_interceptor: @request_interceptor,
-                                                  response_interceptor: @response_interceptor)
+                                                  @forwarder)
       end
 
       def ca_certificate(pem, key)

--- a/lib/ritm/proxy/proxy_server.rb
+++ b/lib/ritm/proxy/proxy_server.rb
@@ -1,15 +1,12 @@
 require 'webrick'
 require 'webrick/httpproxy'
 require 'ritm/helpers/patches'
-require 'ritm/interception/intercept_utils'
 
 module Ritm
   module Proxy
     # Proxy server that accepts request and response intercept handlers for HTTP traffic
     # HTTPS traffic is redirected to the SSLReverseProxy for interception
     class ProxyServer < WEBrick::HTTPProxyServer
-      include InterceptUtils
-
       def start_async
         trap(:TERM) { shutdown }
         trap(:INT) { shutdown }
@@ -28,20 +25,7 @@ module Ritm
       def proxy_service(req, res)
         # Proxy Authentication
         proxy_auth(req, res)
-
-        # Request modifier handler
-        intercept_request(@config[:request_interceptor], req, @config[:ritm_conf].intercept.request)
-
-        begin
-          send("do_#{req.request_method}", req, res)
-        rescue NoMethodError
-          raise WEBrick::HTTPStatus::MethodNotAllowed, "unsupported method `#{req.request_method}'."
-        rescue StandardError => err
-          raise WEBrick::HTTPStatus::ServiceUnavailable, err.message
-        end
-
-        # Response modifier handler
-        intercept_response(@config[:response_interceptor], req, res, @config[:ritm_conf].intercept.response)
+        @config[:forwarder].forward(req, res)
       end
 
       # Override

--- a/lib/ritm/proxy/ssl_reverse_proxy.rb
+++ b/lib/ritm/proxy/ssl_reverse_proxy.rb
@@ -11,9 +11,8 @@ module Ritm
       # Creates a HTTPS server with the given settings
       # @param port [Fixnum]: TCP port to bind the service
       # @param ca [Ritm::CA]: The certificate authority used to sign fake server certificates
-      # @param request_interceptor [Proc]: If given, it will be invoked before proxying the request
-      # @param response_interceptor [Proc]: If give, it will be invoked before sending back the response
-      def initialize(port, ca, conf, request_interceptor: nil, response_interceptor: nil)
+      # @param forwarder [Ritm::HTTPForwarder]: Forwards http traffic with interception
+      def initialize(port, ca, forwarder)
         @ca = ca
         default_vhost = 'localhost'
         @server = CertSigningHTTPSServer.new(Port: port,
@@ -21,8 +20,7 @@ module Ritm
                                              Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
                                              ca: ca,
                                              **vhost_settings(default_vhost))
-
-        @server.mount '/', RequestInterceptorServlet, request_interceptor, response_interceptor, conf
+        @server.mount '/', RequestInterceptorServlet, forwarder
       end
 
       def start_async

--- a/lib/ritm/version.rb
+++ b/lib/ritm/version.rb
@@ -1,4 +1,3 @@
-# Ritm version
 module Ritm
   VERSION = '1.0.2'.freeze
 end

--- a/ritm.gemspec
+++ b/ritm.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rubocop', '~> 0.51'
   s.add_development_dependency 'simplecov', '~> 0.15'
-  s.add_development_dependency 'sinatra', '~> 1.4'
+  s.add_development_dependency 'sinatra', '~> 2.0'
+  s.add_development_dependency 'sinatra-contrib', '~> 2.0'
   s.add_development_dependency 'thin', '~> 1.7'
 end

--- a/spec/helpers/web_server.rb
+++ b/spec/helpers/web_server.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'thin'
 require 'sinatra/base'
+require 'sinatra/cookies'
 
 class ThinHttpsBackend < Thin::Backends::TcpServer
   def initialize(host, port, ssl_options)
@@ -11,6 +12,7 @@ class ThinHttpsBackend < Thin::Backends::TcpServer
 end
 
 class WebServer < Sinatra::Base
+  helpers Sinatra::Cookies
   set :environment, :test
   set :server, :thin
   set :bind, '127.0.0.1'
@@ -35,6 +37,10 @@ class WebServer < Sinatra::Base
 
   get '/ping' do
     'pong'
+  end
+
+  get '/cookies' do
+    params.each { |name, value| response.set_cookie(name, value: value, expires: Time.now + 3600) }
   end
 
   get '/encoded/gzip' do

--- a/spec/intercept_spec.rb
+++ b/spec/intercept_spec.rb
@@ -4,200 +4,209 @@ require 'json'
 require 'ritm'
 require 'helpers/ritm_spec_utils'
 
+protocols = { http: 'http://localhost:4567', https: 'https://localhost:4443' }
+
 RSpec.describe Ritm do
   include RitmSpecUtils
 
-  %w[http://localhost:4567 https://localhost:4443].each do |base_url|
-    before(:each) do
-      interceptor.clear
-    end
+  protocols.each do |protocol, base_url|
+    before(:each) { interceptor.clear }
 
-    it 'intercepts requests and responses' do
-      expect(interceptor.requests.size).to eq 0
-      expect(interceptor.responses.size).to eq 0
-      client(base_url).get('/ping')
-      expect(interceptor.requests.size).to eq 1
-      expect(interceptor.responses.size).to eq 1
-    end
-
-    it 'can disable interception temporarily' do
-      expect(interceptor.requests.size).to eq 0
-      expect(interceptor.responses.size).to eq 0
-      Ritm.disable
-      client(base_url).get('/ping')
-      expect(interceptor.requests.size).to eq 0
-      expect(interceptor.responses.size).to eq 0
-      Ritm.enable
-      client(base_url).get('/ping')
-      expect(interceptor.requests.size).to eq 1
-      expect(interceptor.responses.size).to eq 1
-    end
-
-    it 'can be configured to use upstream proxies' do
-      resp = nil
-      with_proxy do |session|
-        c = client(base_url, verify_ssl: false, proxy: 'http://localhost:7777')
-        c.get('/ping')
+    describe protocol do
+      it 'intercepts requests and responses' do
         expect(interceptor.requests.size).to eq 0
         expect(interceptor.responses.size).to eq 0
-
-        session.configure { misc[:upstream_proxy] = DEFAULT_PROXY_ADDRESS }
-
-        resp = c.get('/ping')
+        client(base_url).get('/ping')
         expect(interceptor.requests.size).to eq 1
         expect(interceptor.responses.size).to eq 1
       end
-      expect(resp.body).to eq 'pong'
-    end
 
-    describe 'when intercepting requests' do
-      it 'intercepts requests before they are sent' do
-        exec_order = [:a]
-        interceptor.on_request = proc do |_req|
-          exec_order << :c
-        end
-        exec_order << :b
+      it 'can disable interception temporarily' do
+        expect(interceptor.requests.size).to eq 0
+        expect(interceptor.responses.size).to eq 0
+        Ritm.disable
         client(base_url).get('/ping')
-        exec_order << :d
-        expect(exec_order).to eq(%i[a b c d])
+        expect(interceptor.requests.size).to eq 0
+        expect(interceptor.responses.size).to eq 0
+        Ritm.enable
+        client(base_url).get('/ping')
+        expect(interceptor.requests.size).to eq 1
+        expect(interceptor.responses.size).to eq 1
       end
 
-      it 'gets access to method, resource, headers, and body' do
-        client(base_url).post('/echo?query=string') do |r|
-          r.headers['Content-Type'] = 'application/json'
-          r.body = '{ "password": "12345" }'
+      it 'can be configured to use upstream proxies' do
+        resp = nil
+        with_proxy do |session|
+          c = client(base_url, verify_ssl: false, proxy: 'http://localhost:7777')
+          c.get('/ping')
+          expect(interceptor.requests.size).to eq 0
+          expect(interceptor.responses.size).to eq 0
+
+          session.configure { misc[:upstream_proxy] = DEFAULT_PROXY_ADDRESS }
+
+          resp = c.get('/ping')
+          expect(interceptor.requests.size).to eq 1
+          expect(interceptor.responses.size).to eq 1
         end
-        req = interceptor.requests.last
-        expect(req.request_method).to eq('POST')
-        expect(req.request_uri.to_s).to eq("#{base_url}/echo?query=string")
-        expect(req.header['content-type']).to eq(['application/json'])
-        expect(req.body).to eq('{ "password": "12345" }')
+        expect(resp.body).to eq 'pong'
       end
 
-      it 'can modify method, resource, headers, and body' do
-        interceptor.on_request = proc do |req|
-          req.request_method = 'PUT'
-          req.request_uri = URI("#{base_url}/echo?arg=1")
-          req['content-type'] = 'text/plain'
-          req.body = '{ "password": "666" }'
-        end
-        response = client(base_url).post('/echo') do |req|
-          req.headers['Content-Type'] = 'application/json'
-          req.body = '{ "password": "12345" }'
-        end
-        res = JSON.parse(response.body, symbolize_names: true)
-        expect(res[:method]).to eq('PUT')
-        expect(res[:path]).to eq('/echo')
-        expect(res[:query]).to eq('arg=1')
-        expect(res[:body]).to eq('{ "password": "666" }')
-        expect(res[:headers][:'content-type']).to eq('text/plain')
-        # TODO: implement changing host:port when intercepting
-        # expect(res[:headers][:host]).to eq('127.0.0.1.xip.io:4567')
-      end
-
-      describe 'content-length' do
-        it 'should update content-length automatically by default' do
-          interceptor.on_request = proc { |req| req.body = '123' }
-          response = client(base_url).post('/echo') { |req| req.body = '1234567890' }
-          received_request = JSON.parse(response.body, symbolize_names: true)
-          expect(received_request[:headers][:'content-length']).to eq('3')
+      describe 'when intercepting requests' do
+        it 'intercepts requests before they are sent' do
+          exec_order = [:a]
+          interceptor.on_request = proc do |_req|
+            exec_order << :c
+          end
+          exec_order << :b
+          client(base_url).get('/ping')
+          exec_order << :d
+          expect(exec_order).to eq(%i[a b c d])
         end
 
-        it 'should not update the content-length when disabled' do
-          skip 'Net:HTTP seems to always update content-length'
+        it 'gets access to method, resource, headers, and body' do
+          client(base_url).post('/echo?query=string') do |r|
+            r.headers['Content-Type'] = 'application/json'
+            r.body = '{ "password": "12345" }'
+          end
+          req = interceptor.requests.last
+          expect(req.request_method).to eq('POST')
+          expect(req.request_uri.to_s).to eq("#{base_url}/echo?query=string")
+          expect(req.header['content-type']).to eq(['application/json'])
+          expect(req.body).to eq('{ "password": "12345" }')
+        end
 
-          with_proxy do |session|
-            c = client(base_url, verify_ssl: false, proxy: 'http://localhost:7777')
-            session.configure { intercept[:request][:update_content_length] = false }
-            session.on_request { |req| req.body = '123' }
-            response = c.post('/echo') { |req| req.body = '1234567890' }
+        it 'can modify method, resource, headers, and body' do
+          interceptor.on_request = proc do |req|
+            req.request_method = 'PUT'
+            req.request_uri = URI("#{base_url}/echo?arg=1")
+            req['content-type'] = 'text/plain'
+            req.body = '{ "password": "666" }'
+          end
+          response = client(base_url).post('/echo') do |req|
+            req.headers['Content-Type'] = 'application/json'
+            req.body = '{ "password": "12345" }'
+          end
+          res = JSON.parse(response.body, symbolize_names: true)
+          expect(res[:method]).to eq('PUT')
+          expect(res[:path]).to eq('/echo')
+          expect(res[:query]).to eq('arg=1')
+          expect(res[:body]).to eq('{ "password": "666" }')
+          expect(res[:headers][:'content-type']).to eq('text/plain')
+          # TODO: implement changing host:port when intercepting
+          # expect(res[:headers][:host]).to eq('127.0.0.1.xip.io:4567')
+        end
+
+        describe 'content-length' do
+          it 'should update content-length automatically by default' do
+            interceptor.on_request = proc { |req| req.body = '123' }
+            response = client(base_url).post('/echo') { |req| req.body = '1234567890' }
             received_request = JSON.parse(response.body, symbolize_names: true)
-            expect(received_request[:headers][:'content-length']).to eq('10')
+            expect(received_request[:headers][:'content-length']).to eq('3')
+          end
+
+          it 'should not update the content-length when disabled' do
+            skip 'Net:HTTP seems to always update content-length'
+
+            with_proxy do |session|
+              c = client(base_url, verify_ssl: false, proxy: 'http://localhost:7777')
+              session.configure { intercept[:request][:update_content_length] = false }
+              session.on_request { |req| req.body = '123' }
+              response = c.post('/echo') { |req| req.body = '1234567890' }
+              received_request = JSON.parse(response.body, symbolize_names: true)
+              expect(received_request[:headers][:'content-length']).to eq('10')
+            end
           end
         end
       end
-    end
 
-    describe 'when intercepting responses' do
-      it 'intercepts responses before the client gets them' do
-        exec_order = [:a]
-        interceptor.on_response = proc { |_req, _res| exec_order << :c }
-        exec_order << :b
-        client(base_url).get('/ping')
-        exec_order << :d
-        expect(exec_order).to eq(%i[a b c d])
-      end
-
-      it 'gets access to status, headers, and body' do
-        client(base_url).get('/ping')
-        res = interceptor.responses.last
-        expect(res.status).to eq 200
-        expect(res.header['content-length']).to eq('4')
-        expect(res.header['content-type']).to eq('text/html;charset=utf-8')
-        expect(res.body).to eq('pong')
-      end
-
-      it 'can modify status, headers, and body' do
-        interceptor.on_response = proc do |_req, res|
-          res.body = 'plonch'
-          res.status = 404
-          res.header['x-custom'] = 'narf'
-          res.header['content-type'] = 'text/plain'
+      describe 'when intercepting responses' do
+        it 'intercepts responses before the client gets them' do
+          exec_order = [:a]
+          interceptor.on_response = proc { |_req, _res| exec_order << :c }
+          exec_order << :b
+          client(base_url).get('/ping')
+          exec_order << :d
+          expect(exec_order).to eq(%i[a b c d])
         end
-        res = client(base_url).get('/ping')
-        expect(res.status).to eq 404
-        expect(res.headers['content-length']).to eq('6')
-        expect(res.headers['content-type']).to eq('text/plain')
-        expect(res.headers['x-custom']).to eq('narf')
-        expect(res.body).to eq('plonch')
-      end
 
-      describe 'gzip/deflate content encoding' do
-        it 'gets gzip content automatically decoded' do
-          content = nil
+        it 'gets access to status, headers, and body' do
+          client(base_url).get('/ping')
+          res = interceptor.responses.last
+          expect(res.status).to eq 200
+          expect(res.header['content-length']).to eq('4')
+          expect(res.header['content-type']).to eq('text/html;charset=utf-8')
+          expect(res.body).to eq('pong')
+        end
+
+        it 'can modify status, headers, and body' do
           interceptor.on_response = proc do |_req, res|
-            expect(res.header['content-encoding']).to be nil
-            content = res.body
+            res.body = 'plonch'
+            res.status = 404
+            res.header['x-custom'] = 'narf'
+            res.header['content-type'] = 'text/plain'
           end
-          client(base_url).get('/encoded/gzip', payload: 'The gzip payload')
-          expect(content).to eq 'The gzip payload'
+          res = client(base_url).get('/ping')
+          expect(res.status).to eq 404
+          expect(res.headers['content-length']).to eq('6')
+          expect(res.headers['content-type']).to eq('text/plain')
+          expect(res.headers['x-custom']).to eq('narf')
+          expect(res.body).to eq('plonch')
         end
 
-        it 'gets deflate content automatically decoded' do
-          content = nil
-          interceptor.on_response = proc do |_req, res|
-            expect(res.header['content-encoding']).to be nil
-            content = res.body
+        describe 'gzip/deflate content encoding' do
+          it 'gets gzip content automatically decoded' do
+            content = nil
+            interceptor.on_response = proc do |_req, res|
+              expect(res.header['content-encoding']).to be nil
+              content = res.body
+            end
+            client(base_url).get('/encoded/gzip', payload: 'The gzip payload')
+            expect(content).to eq 'The gzip payload'
           end
-          client(base_url).get('/encoded/deflate', payload: 'the deflate payload')
-          expect(content).to eq 'the deflate payload'
-        end
-      end
 
-      describe 'content-length' do
-        it 'should update content-length automatically by default' do
-          interceptor.on_response = proc { |_req, res| res.body = '1234567890' }
-          response = client(base_url).get('/ping')
-          expect(response.headers['content-length']).to eq('10')
-        end
-
-        it 'should not update the content-length when disabled' do
-          with_proxy do |session|
-            session.configure { intercept[:response][:update_content_length] = false }
-            session.on_response { |_req, res| res.body = '1234567890' }
-            response = client(
-              base_url,
-              verify_ssl: false,
-              proxy: 'http://localhost:7777'
-            ).get('/ping')
-            expect(response.headers['content-length']).to eq('4')
+          it 'gets deflate content automatically decoded' do
+            content = nil
+            interceptor.on_response = proc do |_req, res|
+              expect(res.header['content-encoding']).to be nil
+              content = res.body
+            end
+            client(base_url).get('/encoded/deflate', payload: 'the deflate payload')
+            expect(content).to eq 'the deflate payload'
           end
         end
 
-        it 'should update the content-length with the proper size in bytes' do
-          interceptor.on_response = proc { |_req, res| res.body = "\x80\u3042\u3042" }
-          response = client(base_url).get('/ping')
-          expect(response.headers['content-length']).to eq('7')
+        describe 'cookies' do
+          it 'should return include all the cookies set by the server' do
+            response = client(base_url).get('/cookies?name1=value1&name2=value2')
+            expect(response.headers['set-cookie']).to include('name1=value1', 'name2=value2')
+          end
+        end
+
+        describe 'content-length' do
+          it 'should update content-length automatically by default' do
+            interceptor.on_response = proc { |_req, res| res.body = '1234567890' }
+            response = client(base_url).get('/ping')
+            expect(response.headers['content-length']).to eq('10')
+          end
+
+          it 'should not update the content-length when disabled' do
+            with_proxy do |session|
+              session.configure { intercept[:response][:update_content_length] = false }
+              session.on_response { |_req, res| res.body = '1234567890' }
+              response = client(
+                base_url,
+                verify_ssl: false,
+                proxy: 'http://localhost:7777'
+              ).get('/ping')
+              expect(response.headers['content-length']).to eq('4')
+            end
+          end
+
+          it 'should update the content-length with the proper size in bytes' do
+            interceptor.on_response = proc { |_req, res| res.body = "\x80\u3042\u3042" }
+            response = client(base_url).get('/ping')
+            expect(response.headers['content-length']).to eq('7')
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |c|
     https_pid = fork { SslWebServer.run! }
     Thread.pass
   end
+
   c.after(:suite) do
     Ritm.shutdown
     Process.kill('INT', http_pid)


### PR DESCRIPTION
* Some set-cookie headers were not properly parsed, causing the user agent to miss some cookies. This was making it impossible to log into sites like gmail or instagram.
* Faraday was urlencoding values in the querystring, causing some sites to behave weird. Now using a custom encoder that does not do magic stuff