### PR TITLE
Add SubjectAltName into certificate

### DIFF
--- a/lib/ritm/certs/ca.rb
+++ b/lib/ritm/certs/ca.rb
@@ -20,9 +20,9 @@ module Ritm
       end
     end
 
-    def sign(certificate)
+    def sign(certificate, extensions = self.class.signing_profile)
       certificate.cert.parent = @cert
-      certificate.cert.sign!(self.class.signing_profile)
+      certificate.cert.sign!(extensions)
     end
 
     def self.signing_profile

--- a/lib/ritm/certs/certificate.rb
+++ b/lib/ritm/certs/certificate.rb
@@ -20,7 +20,7 @@ module Ritm
       cert.subject.country = 'AR'
       cert.not_before = cert.not_before - 3600 * 24 * 30 # Substract 30 days
       cert.serial_number.number = serial_number || common_name.hash.abs
-      cert.key_material.generate_key(1024)
+      cert.key_material.generate_key(2048)
       yield cert if block_given?
       new cert
     end

--- a/lib/ritm/proxy/cert_signing_https_server.rb
+++ b/lib/ritm/proxy/cert_signing_https_server.rb
@@ -1,4 +1,3 @@
-require 'net/http'
 require 'openssl'
 require 'webrick'
 require 'webrick/https'


### PR DESCRIPTION
Hi, I found that the browser would raise an error if remote https certificate has no SAN extension, like Chrome below:

```
Error: "Subject Alternative Name Missing"
```

Generating a fake SAN extension can fix this error.
Also, I change the CA public key length to 2048 that can avoid browser alerting.