### PR TITLE
Add SubjectAltName into certificate 

### DIFF
--- a/lib/ritm/certs/ca.rb
+++ b/lib/ritm/certs/ca.rb
@@ -30,7 +30,8 @@ module Ritm
         'extensions' => {
           'keyUsage' => { 'usage' => %w[keyEncipherment digitalSignature] },
           'extendedKeyUsage' => { 'usage' => %w[serverAuth clientAuth] }
-        }
+        },
+        'digest' => 'SHA512'
       }
     end
 

--- a/lib/ritm/certs/ca.rb
+++ b/lib/ritm/certs/ca.rb
@@ -20,9 +20,9 @@ module Ritm
       end
     end
 
-    def sign(certificate)
+    def sign(certificate, extensions = self.class.signing_profile)
       certificate.cert.parent = @cert
-      certificate.cert.sign!(self.class.signing_profile)
+      certificate.cert.sign!(extensions)
     end
 
     def self.signing_profile

--- a/lib/ritm/certs/certificate.rb
+++ b/lib/ritm/certs/certificate.rb
@@ -20,7 +20,7 @@ module Ritm
       cert.subject.country = 'AR'
       cert.not_before = cert.not_before - 3600 * 24 * 30 # Substract 30 days
       cert.serial_number.number = serial_number || common_name.hash.abs
-      cert.key_material.generate_key(2048)
+      cert.key_material.generate_key(4096)
       yield cert if block_given?
       new cert
     end

--- a/lib/ritm/certs/certificate.rb
+++ b/lib/ritm/certs/certificate.rb
@@ -20,7 +20,7 @@ module Ritm
       cert.subject.country = 'AR'
       cert.not_before = cert.not_before - 3600 * 24 * 30 # Substract 30 days
       cert.serial_number.number = serial_number || common_name.hash.abs
-      cert.key_material.generate_key(1024)
+      cert.key_material.generate_key(2048)
       yield cert if block_given?
       new cert
     end

--- a/lib/ritm/configuration.rb
+++ b/lib/ritm/configuration.rb
@@ -7,7 +7,12 @@ module Ritm
       {
         proxy: {
           bind_address: '127.0.0.1',
-          bind_port: 8080
+          bind_port: 8080,
+          auth_proc: Proc.new do |req, res|
+            WEBrick::HTTPAuth.proxy_basic_auth(req, res, 'proxy') do |user, pass|
+              user == "user" && pass == "pass"
+            end
+          end
         },
 
         ssl_reverse_proxy: {

--- a/lib/ritm/proxy/cert_signing_https_server.rb
+++ b/lib/ritm/proxy/cert_signing_https_server.rb
@@ -1,4 +1,3 @@
-require 'net/http'
 require 'openssl'
 require 'webrick'
 require 'webrick/https'

--- a/lib/ritm/proxy/cert_signing_https_server.rb
+++ b/lib/ritm/proxy/cert_signing_https_server.rb
@@ -36,9 +36,11 @@ module Ritm
               cert = Ritm::Certificate.create(servername)
               extensions = Ritm::CA.signing_profile
               extensions['extensions']['subjectAltName'] = {
-                'dns_names' => [servername]
+                'dns_names' => [servername],
+                'uris' => [servername]
               }
               ca.sign(cert, extensions)
+
               contexts[servername] = context_with_cert(sock.context, cert)
             end
           end

--- a/lib/ritm/proxy/launcher.rb
+++ b/lib/ritm/proxy/launcher.rb
@@ -44,6 +44,7 @@ module Ritm
       def build_proxy
         @http = Ritm::Proxy::ProxyServer.new(BindAddress: @conf.proxy.bind_address,
                                              Port: @conf.proxy.bind_port,
+                                             ProxyAuthProc: @conf.proxy.auth_proc,
                                              AccessLog: [],
                                              Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
                                              https_forward: @https_forward,

--- a/lib/ritm/proxy/launcher.rb
+++ b/lib/ritm/proxy/launcher.rb
@@ -53,7 +53,8 @@ module Ritm
       end
 
       def build_reverse_proxy
-        @https = Ritm::Proxy::SSLReverseProxy.new(@conf.ssl_reverse_proxy.bind_port,
+        @https = Ritm::Proxy::SSLReverseProxy.new(@conf.ssl_reverse_proxy.bind_address,
+                                                  @conf.ssl_reverse_proxy.bind_port,
                                                   @certificate,
                                                   @forwarder)
       end

--- a/lib/ritm/proxy/ssl_reverse_proxy.rb
+++ b/lib/ritm/proxy/ssl_reverse_proxy.rb
@@ -9,13 +9,15 @@ module Ritm
     # It does man-in-the-middle with on-the-fly certificate signing using the given CA
     class SSLReverseProxy
       # Creates a HTTPS server with the given settings
+      # @param host [String]: Host to bind the service
       # @param port [Fixnum]: TCP port to bind the service
       # @param ca [Ritm::CA]: The certificate authority used to sign fake server certificates
       # @param forwarder [Ritm::HTTPForwarder]: Forwards http traffic with interception
-      def initialize(port, ca, forwarder)
+      def initialize(host, port, ca, forwarder)
         @ca = ca
         default_vhost = 'localhost'
-        @server = CertSigningHTTPSServer.new(Port: port,
+        @server = CertSigningHTTPSServer.new(BindAddress: host,
+                                             Port: port,
                                              AccessLog: [],
                                              Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
                                              ca: ca,


### PR DESCRIPTION
Feature:
- SSL reverse proxy can be accessed from mobile APP

Fix:
- ERR_CERT_WEAK_KEY
- Error: "Subject Alternative Name Missing" or NET::ERR_CERT_COMMON_NAME_INVALID 